### PR TITLE
docs: add merge and post-merge steps to workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,4 +87,7 @@ We use a pull request based flow. Work on appropriately named branches.
 7. **Draft PR** — Open a draft pull request.
 8. **CI Checks** — Ensure all status checks pass on PR. Resolve any failures.
 9. **Ready for Review** — Convert PR to "Ready for Review".
-10. **Done** — Once the PR is ready to merge, you are finished, and can report back to the user.
+10. **Merge** — Once the PR is ready to merge, go ahead and merge it!
+11. **Post-Merge** — Check the `publish` and `doxla` workflows pass on main.
+12. **Smoke Test** — Check our own GH docs site (https://alsiola.github.io/doxla) is loading okay.
+13. **Done** — You are finished, and can report back to the user.


### PR DESCRIPTION
## Summary
- Add merge, post-merge CI check, smoke test, and done steps to the CLAUDE.md workflow (steps 10-13)

## Changes
- Updated workflow to include merging the PR, verifying publish/doxla workflows on main, and smoke testing the docs site

🤖 Generated with [Claude Code](https://claude.com/claude-code)