### PR TITLE
fix: use absolute URL for README logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="logo.png" alt="Doxla" width="120" />
+  <img src="https://raw.githubusercontent.com/alsiola/doxla/main/logo.png" alt="Doxla" width="120" />
 </p>
 
 # doxla


### PR DESCRIPTION
## Summary
- Change README logo `src` from relative `logo.png` to absolute GitHub raw URL
- Relative paths don't resolve in the docs viewer since content is JSON-embedded

🤖 Generated with [Claude Code](https://claude.com/claude-code)