### PR TITLE
fix: resolve relative image paths and copy to build output

### DIFF
--- a/src/cli/commands/build.ts
+++ b/src/cli/commands/build.ts
@@ -32,13 +32,13 @@ export async function buildCommand(options: BuildOptions) {
 
   // Step 2: Generate manifest
   const manifestSpinner = ora("Generating manifest...").start();
-  const manifest = await generateManifest(rootDir, files);
+  const { manifest, images } = await generateManifest(rootDir, files);
   manifestSpinner.succeed("Manifest generated");
 
   // Step 3: Build docs viewer
   const buildSpinner = ora("Building docs viewer...").start();
   try {
-    await buildApp(manifest, { output: outputDir, basePath });
+    await buildApp(manifest, { output: outputDir, basePath, rootDir, images });
     buildSpinner.succeed("Docs viewer built");
   } catch (error) {
     buildSpinner.fail("Build failed");

--- a/src/cli/lib/build-app.ts
+++ b/src/cli/lib/build-app.ts
@@ -9,6 +9,8 @@ import { getTemplatePath } from "./template.js";
 interface BuildOptions {
   output: string;
   basePath: string;
+  rootDir: string;
+  images: string[];
 }
 
 export async function buildApp(
@@ -31,6 +33,18 @@ export async function buildApp(
       JSON.stringify(manifest, null, 2),
       "utf-8"
     );
+
+    // Copy referenced images to public dir
+    if (options.images.length > 0) {
+      const publicDir = join(tempDir, "public");
+      await mkdir(publicDir, { recursive: true });
+      for (const img of options.images) {
+        const src = join(options.rootDir, img);
+        const dest = join(publicDir, img);
+        await mkdir(join(dest, ".."), { recursive: true });
+        await cp(src, dest).catch(() => {});
+      }
+    }
 
     // Install dependencies
     execSync("npm install --no-audit --no-fund", {


### PR DESCRIPTION
## Summary
- Scan markdown content for relative image references (`![](path)` and `<img src="path">`)
- Resolve relative paths to root-relative at manifest generation time
- Copy referenced images from repo root to Vite `public/` dir during build
- Absolute URLs are left untouched
- Images now work in the docs site without needing absolute GitHub URLs

## Changes
- `src/cli/lib/manifest.ts` — Add `resolveImagePaths()`, return `{ manifest, images }` from `generateManifest`
- `src/cli/lib/build-app.ts` — Accept `rootDir` and `images`, copy images to temp `public/`
- `src/cli/commands/build.ts` — Pass new options through
- `tests/cli/manifest.test.ts` — 3 new tests for image path resolution, update destructuring

## Test plan
- [x] All 52 tests pass
- [x] Build succeeds
- [x] Full pipeline confirms `logo.png` appears in build output root
- [x] Relative paths from nested docs resolved correctly
- [x] Absolute URLs left untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)