### PR TITLE
feat: add mobile navigation with slide-out drawer

### DIFF
--- a/src/app/src/components/layout/Header.tsx
+++ b/src/app/src/components/layout/Header.tsx
@@ -1,17 +1,20 @@
 import { useState } from "react";
 import { Search, Sun, Moon } from "lucide-react";
 import type { Theme } from "../../App";
+import type { DocFile } from "../../types/manifest";
 import { Input } from "../ui/Input";
 import { Button } from "../ui/Button";
+import { MobileNav } from "./MobileNav";
 import logoSrc from "../../assets/logo.svg";
 
 interface HeaderProps {
   repoName: string;
+  docs: DocFile[];
   theme: Theme;
   onToggleTheme: () => void;
 }
 
-export function Header({ repoName, theme, onToggleTheme }: HeaderProps) {
+export function Header({ repoName, docs, theme, onToggleTheme }: HeaderProps) {
   const [searchInput, setSearchInput] = useState("");
 
   const handleSearch = (e: React.FormEvent) => {
@@ -22,7 +25,9 @@ export function Header({ repoName, theme, onToggleTheme }: HeaderProps) {
   };
 
   return (
-    <header className="sticky top-0 z-10 flex h-14 items-center gap-4 border-b border-border bg-background px-6">
+    <header className="sticky top-0 z-10 flex h-14 items-center gap-4 border-b border-border bg-background px-4 sm:px-6">
+      <MobileNav docs={docs} />
+
       <a href="#/" className="flex items-center gap-2 font-semibold">
         <img src={logoSrc} alt="Doxla" className="h-5 w-5 object-contain" />
         <span>{repoName}</span>
@@ -36,10 +41,10 @@ export function Header({ repoName, theme, onToggleTheme }: HeaderProps) {
             placeholder="Search docs..."
             value={searchInput}
             onChange={(e) => setSearchInput(e.target.value)}
-            className="w-64 pl-9"
+            className="w-full sm:w-64 pl-9"
           />
         </div>
-        <Button type="submit" size="sm">
+        <Button type="submit" size="sm" className="hidden sm:inline-flex">
           Search
         </Button>
       </form>

--- a/src/app/src/components/layout/Layout.tsx
+++ b/src/app/src/components/layout/Layout.tsx
@@ -14,7 +14,7 @@ interface LayoutProps {
 export function Layout({ manifest, theme, onToggleTheme, children }: LayoutProps) {
   return (
     <div className="min-h-screen">
-      <Header repoName={manifest.repoName} theme={theme} onToggleTheme={onToggleTheme} />
+      <Header repoName={manifest.repoName} docs={manifest.docs} theme={theme} onToggleTheme={onToggleTheme} />
       <div className="flex">
         <Sidebar docs={manifest.docs} />
         <main className="flex-1 overflow-auto">

--- a/src/app/src/components/layout/MobileNav.tsx
+++ b/src/app/src/components/layout/MobileNav.tsx
@@ -1,0 +1,55 @@
+import { useState, useEffect } from "react";
+import { Menu } from "lucide-react";
+import { Button } from "../ui/Button";
+import {
+  Sheet,
+  SheetOverlay,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+} from "../ui/Sheet";
+import { ScrollArea } from "../ui/ScrollArea";
+import { FileTree } from "../FileTree";
+import type { DocFile } from "../../types/manifest";
+
+interface MobileNavProps {
+  docs: DocFile[];
+}
+
+export function MobileNav({ docs }: MobileNavProps) {
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    if (!open) return;
+
+    const close = () => setOpen(false);
+    window.addEventListener("hashchange", close);
+    return () => window.removeEventListener("hashchange", close);
+  }, [open]);
+
+  return (
+    <>
+      <Button
+        size="icon"
+        variant="ghost"
+        className="md:hidden"
+        onClick={() => setOpen(true)}
+        aria-label="Open navigation"
+      >
+        <Menu className="h-5 w-5" />
+      </Button>
+
+      <Sheet open={open} onClose={() => setOpen(false)}>
+        <SheetOverlay />
+        <SheetContent side="left" aria-label="Navigation menu">
+          <SheetHeader>
+            <SheetTitle>Documents</SheetTitle>
+          </SheetHeader>
+          <ScrollArea className="flex-1 px-3 pb-4">
+            <FileTree docs={docs} />
+          </ScrollArea>
+        </SheetContent>
+      </Sheet>
+    </>
+  );
+}

--- a/src/app/src/components/ui/Sheet.tsx
+++ b/src/app/src/components/ui/Sheet.tsx
@@ -1,0 +1,131 @@
+import {
+  createContext,
+  useContext,
+  useEffect,
+  type ReactNode,
+} from "react";
+import { createPortal } from "react-dom";
+import { X } from "lucide-react";
+import { cn } from "../../lib/utils";
+
+interface SheetContextValue {
+  open: boolean;
+  onClose: () => void;
+}
+
+const SheetContext = createContext<SheetContextValue>({
+  open: false,
+  onClose: () => {},
+});
+
+interface SheetProps {
+  open: boolean;
+  onClose: () => void;
+  children: ReactNode;
+}
+
+export function Sheet({ open, onClose, children }: SheetProps) {
+  return (
+    <SheetContext.Provider value={{ open, onClose }}>
+      {children}
+    </SheetContext.Provider>
+  );
+}
+
+export function SheetOverlay() {
+  const { open, onClose } = useContext(SheetContext);
+  if (!open) return null;
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-40 bg-black/60"
+      onClick={onClose}
+      aria-hidden="true"
+    />,
+    document.body
+  );
+}
+
+interface SheetContentProps {
+  side?: "left" | "right";
+  className?: string;
+  "aria-label"?: string;
+  children: ReactNode;
+}
+
+export function SheetContent({
+  side = "left",
+  className,
+  "aria-label": ariaLabel,
+  children,
+}: SheetContentProps) {
+  const { open, onClose } = useContext(SheetContext);
+
+  useEffect(() => {
+    if (!open) return;
+
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      document.body.style.overflow = prev;
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  return createPortal(
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label={ariaLabel}
+      className={cn(
+        "fixed top-0 z-50 flex h-full w-72 flex-col border-r border-border bg-background shadow-lg",
+        side === "left" ? "left-0" : "right-0",
+        className
+      )}
+    >
+      <button
+        onClick={onClose}
+        className="absolute right-3 top-3 rounded-sm p-1 text-muted-foreground hover:text-foreground"
+        aria-label="Close"
+      >
+        <X className="h-4 w-4" />
+      </button>
+      {children}
+    </div>,
+    document.body
+  );
+}
+
+export function SheetHeader({
+  className,
+  children,
+}: {
+  className?: string;
+  children: ReactNode;
+}) {
+  return (
+    <div className={cn("px-4 pt-4 pb-2", className)}>{children}</div>
+  );
+}
+
+export function SheetTitle({
+  className,
+  children,
+}: {
+  className?: string;
+  children: ReactNode;
+}) {
+  return (
+    <h2 className={cn("text-sm font-semibold text-muted-foreground", className)}>
+      {children}
+    </h2>
+  );
+}

--- a/tests/app/Header.test.tsx
+++ b/tests/app/Header.test.tsx
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+
+vi.mock("../../src/app/src/assets/logo.svg", () => ({
+  default: "logo.svg",
+}));
+
+import { Header } from "../../src/app/src/components/layout/Header";
+import type { DocFile } from "../../src/app/src/types/manifest";
+
+const mockDocs: DocFile[] = [
+  { slug: "readme", path: "README.md", title: "README", content: "# Hello" },
+];
+
+describe("Header", () => {
+  it("renders the repo name", () => {
+    render(
+      <Header
+        repoName="my-project"
+        docs={mockDocs}
+        theme="light"
+        onToggleTheme={() => {}}
+      />
+    );
+    expect(screen.getByText("my-project")).toBeTruthy();
+  });
+
+  it("renders the search input", () => {
+    render(
+      <Header
+        repoName="my-project"
+        docs={mockDocs}
+        theme="light"
+        onToggleTheme={() => {}}
+      />
+    );
+    expect(screen.getByPlaceholderText("Search docs...")).toBeTruthy();
+  });
+
+  it("renders the theme toggle button", () => {
+    render(
+      <Header
+        repoName="my-project"
+        docs={mockDocs}
+        theme="light"
+        onToggleTheme={() => {}}
+      />
+    );
+    expect(screen.getByLabelText("Switch to dark mode")).toBeTruthy();
+  });
+
+  it("renders the MobileNav hamburger button", () => {
+    render(
+      <Header
+        repoName="my-project"
+        docs={mockDocs}
+        theme="light"
+        onToggleTheme={() => {}}
+      />
+    );
+    expect(screen.getByLabelText("Open navigation")).toBeTruthy();
+  });
+
+  it("navigates to search on form submit", () => {
+    render(
+      <Header
+        repoName="my-project"
+        docs={mockDocs}
+        theme="light"
+        onToggleTheme={() => {}}
+      />
+    );
+    const input = screen.getByPlaceholderText("Search docs...");
+    fireEvent.change(input, { target: { value: "test query" } });
+    fireEvent.submit(input.closest("form")!);
+    expect(window.location.hash).toBe(
+      `#/search?q=${encodeURIComponent("test query")}`
+    );
+  });
+});

--- a/tests/app/MobileNav.test.tsx
+++ b/tests/app/MobileNav.test.tsx
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import { MobileNav } from "../../src/app/src/components/layout/MobileNav";
+import type { DocFile } from "../../src/app/src/types/manifest";
+
+const mockDocs: DocFile[] = [
+  { slug: "readme", path: "README.md", title: "README", content: "# Hello" },
+  {
+    slug: "docs-guide",
+    path: "docs/guide.md",
+    title: "Guide",
+    content: "# Guide",
+  },
+];
+
+describe("MobileNav", () => {
+  it("renders the hamburger button", () => {
+    render(<MobileNav docs={mockDocs} />);
+    expect(screen.getByLabelText("Open navigation")).toBeTruthy();
+  });
+
+  it("opens the sheet when hamburger is clicked", () => {
+    render(<MobileNav docs={mockDocs} />);
+    fireEvent.click(screen.getByLabelText("Open navigation"));
+    expect(screen.getByRole("dialog")).toBeTruthy();
+    expect(screen.getByText("Documents")).toBeTruthy();
+  });
+
+  it("shows FileTree inside the sheet", () => {
+    render(<MobileNav docs={mockDocs} />);
+    fireEvent.click(screen.getByLabelText("Open navigation"));
+    expect(screen.getByText("README.md")).toBeTruthy();
+  });
+
+  it("closes the sheet on hashchange", () => {
+    render(<MobileNav docs={mockDocs} />);
+    fireEvent.click(screen.getByLabelText("Open navigation"));
+    expect(screen.getByRole("dialog")).toBeTruthy();
+
+    // Simulate navigation
+    act(() => {
+      window.dispatchEvent(new HashChangeEvent("hashchange"));
+    });
+
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+});

--- a/tests/app/Sheet.test.tsx
+++ b/tests/app/Sheet.test.tsx
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import {
+  Sheet,
+  SheetOverlay,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+} from "../../src/app/src/components/ui/Sheet";
+
+describe("Sheet", () => {
+  it("renders content when open", () => {
+    render(
+      <Sheet open={true} onClose={() => {}}>
+        <SheetOverlay />
+        <SheetContent>
+          <p>Sheet content</p>
+        </SheetContent>
+      </Sheet>
+    );
+    expect(screen.getByText("Sheet content")).toBeTruthy();
+  });
+
+  it("does not render content when closed", () => {
+    render(
+      <Sheet open={false} onClose={() => {}}>
+        <SheetOverlay />
+        <SheetContent>
+          <p>Sheet content</p>
+        </SheetContent>
+      </Sheet>
+    );
+    expect(screen.queryByText("Sheet content")).toBeNull();
+  });
+
+  it("has correct ARIA attributes", () => {
+    render(
+      <Sheet open={true} onClose={() => {}}>
+        <SheetContent>
+          <p>Accessible</p>
+        </SheetContent>
+      </Sheet>
+    );
+    const dialog = screen.getByRole("dialog");
+    expect(dialog.getAttribute("aria-modal")).toBe("true");
+  });
+
+  it("calls onClose when overlay is clicked", () => {
+    const onClose = vi.fn();
+    render(
+      <Sheet open={true} onClose={onClose}>
+        <SheetOverlay />
+        <SheetContent>
+          <p>Content</p>
+        </SheetContent>
+      </Sheet>
+    );
+    // The overlay is the aria-hidden div
+    const overlay = document.querySelector("[aria-hidden='true']")!;
+    fireEvent.click(overlay);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onClose when Escape key is pressed", () => {
+    const onClose = vi.fn();
+    render(
+      <Sheet open={true} onClose={onClose}>
+        <SheetContent>
+          <p>Content</p>
+        </SheetContent>
+      </Sheet>
+    );
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onClose when close button is clicked", () => {
+    const onClose = vi.fn();
+    render(
+      <Sheet open={true} onClose={onClose}>
+        <SheetContent>
+          <p>Content</p>
+        </SheetContent>
+      </Sheet>
+    );
+    fireEvent.click(screen.getByLabelText("Close"));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders SheetHeader and SheetTitle", () => {
+    render(
+      <Sheet open={true} onClose={() => {}}>
+        <SheetContent>
+          <SheetHeader>
+            <SheetTitle>My Title</SheetTitle>
+          </SheetHeader>
+        </SheetContent>
+      </Sheet>
+    );
+    expect(screen.getByText("My Title")).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a `Sheet` UI primitive (slide-out panel with overlay, keyboard dismiss, scroll lock, ARIA dialog)
- Adds `MobileNav` component with hamburger button (visible < 768px) that opens a drawer containing the `FileTree`
- Makes the header responsive: search input fills available width on mobile, search button hidden on small screens (Enter key still works)
- Drawer auto-closes on `hashchange` when user navigates to a doc

## Test plan

- [x] `pnpm test` — all 70 tests pass (16 new across Sheet, MobileNav, Header)
- [x] `pnpm build` — CLI builds successfully
- [x] `node dist/cli/index.js build --output doxla-dist` — full build pipeline works
- [ ] Open built site in browser responsive mode:
  - [ ] Hamburger appears below 768px
  - [ ] Tapping hamburger opens drawer with FileTree
  - [ ] Clicking a doc link closes the drawer and navigates
  - [ ] Search input doesn't overflow on mobile
  - [ ] Dark/light theme works in the drawer
  - [ ] Desktop layout unchanged (sidebar visible, no hamburger)

🤖 Generated with [Claude Code](https://claude.com/claude-code)