### PR TITLE
fix: add language tag to directory tree code fence

### DIFF
--- a/docs/custom-components.mdx
+++ b/docs/custom-components.mdx
@@ -12,7 +12,7 @@ This `FeatureCard` is a custom component defined in `docs/components/FeatureCard
 
 By default, Doxla looks for components in `docs/components/`. Create it and add a component:
 
-```
+```text
 my-repo/
   docs/
     components/


### PR DESCRIPTION
## Summary

- Add `text` language tag to the directory tree code fence in `docs/custom-components.mdx` so the syntax highlighter renders it as plain text instead of mangling it

## Test plan
- [ ] Verify the code fence renders cleanly on the docs site

🤖 Generated with [Claude Code](https://claude.com/claude-code)