### PR TITLE
fix: sort root-level sidebar entries (folders first)

### DIFF
--- a/src/app/src/components/FileTree.tsx
+++ b/src/app/src/components/FileTree.tsx
@@ -103,9 +103,17 @@ function TreeItem({
 export function FileTree({ docs }: { docs: DocFile[] }) {
   const tree = buildTree(docs);
 
+  const sortedRoots = Array.from(tree.children.values()).sort((a, b) => {
+    const aIsFolder = a.children.size > 0 && !a.doc;
+    const bIsFolder = b.children.size > 0 && !b.doc;
+    if (aIsFolder && !bIsFolder) return -1;
+    if (!aIsFolder && bIsFolder) return 1;
+    return a.name.localeCompare(b.name);
+  });
+
   return (
     <nav className="space-y-0.5">
-      {Array.from(tree.children.values()).map((node) => (
+      {sortedRoots.map((node) => (
         <TreeItem key={node.path} node={node} depth={0} />
       ))}
     </nav>


### PR DESCRIPTION
## Summary

- Apply folders-first alphabetical sorting to root-level sidebar entries
- The `FileTree` component already sorted children within expanded folders, but root-level nodes were rendered in insertion order (from the manifest)
- Now the `docs` folder appears at the top, followed by files alphabetically

## Test plan
- [x] All 89 tests pass
- [ ] Verify sidebar ordering on docs site

🤖 Generated with [Claude Code](https://claude.com/claude-code)