### PR TITLE
fix: render code blocks without language tag properly

### DIFF
--- a/src/app/src/components/MarkdownRenderer.tsx
+++ b/src/app/src/components/MarkdownRenderer.tsx
@@ -22,7 +22,7 @@ export function MarkdownRenderer({ content, theme, docPath }: MarkdownRendererPr
       code(props) {
         const { children, className, ...rest } = props;
         const match = /language-(\w+)/.exec(className || "");
-        const isInline = !match;
+        const isInline = !match && !String(children).endsWith('\n');
 
         if (isInline) {
           return (
@@ -38,7 +38,7 @@ export function MarkdownRenderer({ content, theme, docPath }: MarkdownRendererPr
         return (
           <SyntaxHighlighter
             style={syntaxStyle}
-            language={match[1]}
+            language={match?.[1] ?? "text"}
             PreTag="div"
             className="rounded-md text-sm"
           >

--- a/src/app/src/components/MdxRenderer.tsx
+++ b/src/app/src/components/MdxRenderer.tsx
@@ -62,7 +62,7 @@ export function MdxRenderer({ content, theme, docPath }: MdxRendererProps) {
     code(props: Record<string, unknown>) {
       const { children, className, ...rest } = props;
       const match = /language-(\w+)/.exec((className as string) || "");
-      const isInline = !match;
+      const isInline = !match && !String(children).endsWith('\n');
 
       if (isInline) {
         return (
@@ -78,7 +78,7 @@ export function MdxRenderer({ content, theme, docPath }: MdxRendererProps) {
       return (
         <SyntaxHighlighter
           style={syntaxStyle}
-          language={match[1]}
+          language={match?.[1] ?? "text"}
           PreTag="div"
           className="rounded-md text-sm"
         >

--- a/tests/app/MarkdownRenderer.test.tsx
+++ b/tests/app/MarkdownRenderer.test.tsx
@@ -14,6 +14,22 @@ describe("MarkdownRenderer", () => {
     expect(screen.getByText("Some paragraph text.")).toBeTruthy();
   });
 
+  it("renders code blocks without a language as styled blocks", () => {
+    const content = "```\nconst x = 1;\n```";
+    const { container } = render(<MarkdownRenderer theme="light" content={content} />);
+    // Should use SyntaxHighlighter (renders a <div> with PreTag="div"), not inline <code>
+    const inlineCode = container.querySelector("code.rounded");
+    expect(inlineCode).toBeNull();
+    expect(screen.getByText("const x = 1;")).toBeTruthy();
+  });
+
+  it("renders inline code as inline elements", () => {
+    render(<MarkdownRenderer theme="light" content="Use `foo` here" />);
+    const codeEl = screen.getByText("foo");
+    expect(codeEl.tagName).toBe("CODE");
+    expect(codeEl.className).toContain("rounded");
+  });
+
   it("renders links", () => {
     render(<MarkdownRenderer theme="light" content="[Click here](https://example.com)" />);
     const link = screen.getByText("Click here");

--- a/tests/app/MdxRenderer.test.tsx
+++ b/tests/app/MdxRenderer.test.tsx
@@ -52,6 +52,25 @@ describe("MdxRenderer", () => {
     });
   });
 
+  it("renders code blocks without a language as styled blocks", async () => {
+    const content = "```\nconst x = 1;\n```";
+    const { container } = render(<MdxRenderer theme="light" content={content} />);
+    await waitFor(() => {
+      const inlineCode = container.querySelector("code.rounded");
+      expect(inlineCode).toBeNull();
+      expect(screen.getByText("const x = 1;")).toBeTruthy();
+    });
+  });
+
+  it("renders inline code as inline elements", async () => {
+    render(<MdxRenderer theme="light" content="Use `foo` here" />);
+    await waitFor(() => {
+      const codeEl = screen.getByText("foo");
+      expect(codeEl.tagName).toBe("CODE");
+      expect(codeEl.className).toContain("rounded");
+    });
+  });
+
   it("resolves relative .mdx links to app routes", async () => {
     const content = "[Link](../other.mdx)";
     render(<MdxRenderer theme="light" content={content} docPath="guides/test.mdx" />);


### PR DESCRIPTION
## Summary
- Code blocks without a language tag (e.g. just ```) were rendered as inline `<code>` elements instead of through SyntaxHighlighter, resulting in unstyled white text on a dark background
- Fixed inline detection in both `MarkdownRenderer` and `MdxRenderer` to check for trailing newline (which fenced code blocks always have) rather than relying solely on language class
- Falls back to `language="text"` for proper block styling without syntax coloring

## Test plan
- [x] Added tests for code blocks without language tag rendering as blocks (not inline)
- [x] Added tests for inline code still rendering as inline elements
- [x] All 93 existing tests pass
- [x] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)